### PR TITLE
fix(auth): properly handle refresh token for access token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
         "@types/bcrypt": "^6.0.0",
+        "@types/cookie-parser": "^1.4.10",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.0.0",
@@ -3114,6 +3115,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cookiejar": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
     "@types/bcrypt": "^6.0.0",
+    "@types/cookie-parser": "^1.4.10",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.0.0",

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -9,65 +9,65 @@ import { ChangePasswordDto } from 'src/dtos/ChangePassword/change-password.dto';
 import { UseGuards, Req } from "@nestjs/common";
 import { AuthGuard } from "src/guards/auth.guard";
 import { ChangePasswordAfterLoginDto } from "src/dtos/ChangePassword/change-password-after-login.dto";
-import type { Response } from 'express';
+import type { Response, Request } from 'express';
 
+interface RequestWithCookies extends Request {
+  cookies: { [key: string]: string };
+}
 @Controller('auth')
 export class AuthController {
     constructor(private readonly AuthService: AuthService) { }
 
-    @Post('register')
-    @UseInterceptors(
-        FileInterceptor('profile_img', {
-            fileFilter: (req, file, cb) => {
-                if (file.originalname.match(/^.*\.(jpg|jpeg|png|webp)$/)) cb(null, true);
-                else cb(new MulterError('LIMIT_UNEXPECTED_FILE', 'profile_img'), false);
-            },
-            limits: { fileSize: 2 * 1024 * 1024 },
-            storage: diskStorage({
-                destination: './uploads',
-                filename: (req, file, cb) => {
-                    cb(null, Date.now() + '-' + file.originalname);
-                },
-            }),
-        }),
-    )
-    register(
-        @UploadedFile() file: Express.Multer.File,
-        @Body() data: RegisterDto
-    ) {
-        if (!file) throw new BadRequestException('Profile image is required');
+   @Post('register')
+  @UseInterceptors(
+    FileInterceptor('profile_img', {
+      fileFilter: (req, file, cb) => {
+        if (file.originalname.match(/^.*\.(jpg|jpeg|png|webp)$/)) cb(null, true);
+        else cb(new MulterError('LIMIT_UNEXPECTED_FILE', 'profile_img'), false);
+      },
+      limits: { fileSize: 2 * 1024 * 1024 },
+      storage: diskStorage({
+        destination: './uploads',
+        filename: (req, file, cb) => {
+          cb(null, Date.now() + '-' + file.originalname);
+        },
+      }),
+    }),
+  )
+  register(@UploadedFile() file: Express.Multer.File, @Body() data: RegisterDto) {
+    if (!file) throw new BadRequestException('Profile image is required');
 
-        data.profile_img = `/uploads/${file.filename}`;
-        return this.AuthService.register(data);
+    data.profile_img = `/uploads/${file.filename}`;
+    return this.AuthService.register(data);
+  }
+
+
+  @Post('login')
+  async login(@Body() data: LoginDto, @Res({ passthrough: true }) res: Response) {
+    const result = await this.AuthService.login(data);
+
+    // Set refresh token in HttpOnly cookie
+    res.cookie('refresh_token', result.refresh_token, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 3 * 24 * 60 * 60 * 1000, 
+    });
+
+    return result; 
+  }
+
+
+  @Post('refresh')
+  refresh(@Req() req: RequestWithCookies) {
+    const refreshToken = req.cookies?.refresh_token;
+
+    if (!refreshToken) {
+      throw new UnauthorizedException('No refresh token');
     }
 
-    @Post('login')
-    async login(@Body() data: LoginDto, @Res({ passthrough: true }) res: Response) {
-        const result = await this.AuthService.login(data);
-
-        // Set refresh token as HttpOnly cookie
-        res.cookie('refresh_token', result.refresh_token, {
-            httpOnly: true,
-            secure: false,
-            sameSite: 'lax',
-            maxAge: 3 * 24 * 60 * 60 * 1000,
-        });
-        return result;
-    }
-
-@Post('refresh')
-refresh(@Req() req: Request) {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const cookies = (req as any).cookies; // quick fix
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const refreshToken = cookies['refresh_token'];
-
-  if (!refreshToken) throw new UnauthorizedException();
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  return this.AuthService.refreshTokens({ token: refreshToken });
-}
-
+    return this.AuthService.refreshTokens({ token: refreshToken });
+  }
 
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { join } from 'path';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -19,8 +20,10 @@ async function bootstrap() {
     prefix: '/uploads/',
   });
 
+  app.use(cookieParser());
+
   app.enableCors({
-    origin: 'http://localhost:4000', 
+    origin: 'http://localhost:3001', 
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true,
   });


### PR DESCRIPTION
- Added RequestWithCookies interface to safely access req.cookies in TypeScript
- Updated /auth/refresh endpoint to use RequestWithCookies
- Ensured login sets secure HttpOnly refresh cookie in production
- Fixed TypeScript errors with cookie-parser import and usage
- Access token returned by login is now stored in localStorage for Authorization header
- Fixed bug where access token could not be refreshed due to missing cookies